### PR TITLE
Fix grain ID list type

### DIFF
--- a/sandpiper_api.yaml
+++ b/sandpiper_api.yaml
@@ -198,7 +198,7 @@ components:
       description: One or more grain IDs
       type: array
       items:
-        type: integer
+        $ref: "#/components/schemas/v4_uuid"
     grain_ids_msg:
       description: One or more grain IDs with a sandpiper message
       type: object


### PR DESCRIPTION
This should have been a UUID, not an integer. Thanks to Luke Smith for spotting.