### PR TITLE
Renamed grains object inside grain_id_list

### DIFF
--- a/sandpiper_api.yaml
+++ b/sandpiper_api.yaml
@@ -206,7 +206,7 @@ components:
         - grain_ids
         - message
       properties:
-        grains:
+        grain_ids:
           $ref: "#/components/schemas/grain_ids"
         message:
           $ref: "#/components/schemas/sandpiper_message"


### PR DESCRIPTION
Was named "grains" but this is distinct -- a list of UUIDs, not a grain object. This could have caused confusion.