### PR TITLE
Bump version number of OpenAPI spec

### DIFF
--- a/sandpiper_api.yaml
+++ b/sandpiper_api.yaml
@@ -9,7 +9,7 @@ info:
   license:
     name: Artistic License 2.0
     url: "https://www.perlfoundation.org/artistic-license-20.html"
-  version: 0.9.13
+  version: 0.9.14
 
 components:
   securitySchemes:


### PR DESCRIPTION
Apologies, I forgot to adjust this when I made the breaking change to the grain_id_list grains object.